### PR TITLE
[SECURITY-825] useFirstPass is not allowed module option name in AbstractServerLoginModule

### DIFF
--- a/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/auth/spi/AbstractServerLoginModule.java
+++ b/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/auth/spi/AbstractServerLoginModule.java
@@ -77,7 +77,7 @@ public abstract class AbstractServerLoginModule implements LoginModule
   
    private static final String[] ALL_VALID_OPTIONS =
    {
-	   PASSWORD_STACKING,USE_FIRST_PASSWORD,PRINCIPAL_CLASS,UNAUTHENTICATED_IDENTITY,
+	   PASSWORD_STACKING,PRINCIPAL_CLASS,UNAUTHENTICATED_IDENTITY,
 	   SecurityConstants.SECURITY_DOMAIN_OPTION
    };
    


### PR DESCRIPTION
The value was only removed from an array which holds option names for module option validator.
