### PR TITLE
SECURITY-845 : keeping a reference on the context class loader used to create

### DIFF
--- a/security-spi/common/src/main/java/org/jboss/security/PicketBoxLogger.java
+++ b/security-spi/common/src/main/java/org/jboss/security/PicketBoxLogger.java
@@ -719,4 +719,9 @@ public interface PicketBoxLogger extends BasicLogger {
     @LogMessage(level = Logger.Level.ERROR)
     @Message(id = 374, value = "Error getting ServerAuthContext for authContextId %s and security domain %s")
     void errorGettingServerAuthContext(String authContextId, String securityDomain, @Cause Throwable cause);
+    
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 375, value = "Error getting the module classloader informations for cache")
+    void errorGettingModuleInformation(@Cause Throwable cause);
+    
 }


### PR DESCRIPTION
a LoginContext so that we can clean it when the classloader is to be unloaded.

Jira: https://issues.jboss.org/browse/SECURITY-845
