### PR TITLE
Fix checking of returned value from Cipher.getMaxAllowedKeyLength

### DIFF
--- a/security-jboss-sx/jbosssx/src/main/java/org/jboss/crypto/CryptoUtil.java
+++ b/security-jboss-sx/jbosssx/src/main/java/org/jboss/crypto/CryptoUtil.java
@@ -476,7 +476,7 @@ public class CryptoUtil
       boolean hasUnlimitedCrypto = false;
       try
       { 
-         hasUnlimitedCrypto = javax.crypto.Cipher.getMaxAllowedKeyLength("Blowfish") > 128;
+         hasUnlimitedCrypto = javax.crypto.Cipher.getMaxAllowedKeyLength("Blowfish") == Integer.MAX_VALUE;
       }
       catch(Throwable e)
       {


### PR DESCRIPTION
Simple fix related to EAP BZ: https://bugzilla.redhat.com/show_bug.cgi?id=901312

The java docs for getMaxAllowedKeyLength note:
"If JCE unlimited strength jurisdiction policy files are installed, Integer.MAX_VALUE will be returned."
