### PR TITLE
SECURITY-859 always report the cause of authentication failure at debug level

### DIFF
--- a/picketbox-infinispan/src/main/java/org/jboss/security/authentication/JBossCachedAuthenticationManager.java
+++ b/picketbox-infinispan/src/main/java/org/jboss/security/authentication/JBossCachedAuthenticationManager.java
@@ -367,9 +367,7 @@ public class JBossCachedAuthenticationManager implements AuthenticationManager, 
 	   }
 	   catch (LoginException e)
 	   {
-		   // Don't log anonymous user failures unless trace level logging is on
-		   if (principal != null && principal.getName() != null)
-               PicketBoxLogger.LOGGER.debugFailedLogin(e);
+		   PicketBoxLogger.LOGGER.debugFailedLogin(e);
 		   authException = e;
 	   }
 	   // Set the security association thread context info exception


### PR DESCRIPTION
A fix for 4.0.21 version.

https://issues.jboss.org/browse/SECURITY-859
