### PR TITLE
SECURITY-786 Improve Memory Performance

### DIFF
--- a/security-spi/spi/src/main/java/org/jboss/security/javaee/AbstractJavaEEHelper.java
+++ b/security-spi/spi/src/main/java/org/jboss/security/javaee/AbstractJavaEEHelper.java
@@ -95,9 +95,10 @@ public abstract class AbstractJavaEEHelper
    {
       if(securityContext.getAuditManager() == null)
          return;
-      Map<String,Object> auditContextMap = new HashMap<String,Object>();
-      auditContextMap.putAll(resource.getMap());
-      auditContextMap.put("Resource:", resource.toString());
+      Map<String, Object> contextualMap = resource.getMap();
+      Map<String,Object> auditContextMap = new HashMap<String,Object>(contextualMap.size() + 3);
+      auditContextMap.putAll(contextualMap);
+      auditContextMap.put("Resource:", resource);
       auditContextMap.put("Action", "authorization");
       if (e != null) {
          //Authorization Exception stacktrace is huge. Scale it down


### PR DESCRIPTION
We did some profiling of or JBoss AS instance and noticed that audit
logging on JavaEE resources is causing most of our allocations outside
[TLAB](http://openjdk.java.net/groups/hotspot/docs/HotSpotGlossary.html#TLAB) s. This was a bit surprising to use since we don't have audit
logging on. We tracked them down to
`org.jboss.security.javaee.AbstractJavaEEHelper.authorizationAudit`
which unnecessarily does an eager string conversion of every
`org.jboss.security.authorization.Resource`. This could be done lazily
on demand when audit logging is on in `AuditEvent#toString`. Since the
map is already of type `Map<String,Object>` simply removing the
call to `#toString()` fixes this.
- don't do eager string conversion of resources in
  `AbstractJavaEEHelper#authorizationAudit`

Issue: SECURITY-786
https://issues.jboss.org/browse/SECURITY-786
