### PR TITLE
SECURITY-787 Speed up SimpleRole#equals

### DIFF
--- a/security-jboss-sx/identity/src/main/java/org/jboss/security/identity/plugins/SimpleRole.java
+++ b/security-jboss-sx/identity/src/main/java/org/jboss/security/identity/plugins/SimpleRole.java
@@ -112,9 +112,13 @@ public class SimpleRole implements Role, Cloneable
    @Override
    public boolean equals(Object obj)
    {
+      if (obj == this)
+      {
+         return true;
+      }
       if (obj instanceof SimpleRole)
       {
-         SimpleRole other = SimpleRole.class.cast(obj);
+         SimpleRole other = (SimpleRole) obj;
          return parent != null ? (roleName.equals(other.roleName) && parent.equals(other.parent)) :
                  (roleName.equals(other.roleName) && other.parent == null);
       }


### PR DESCRIPTION
We did some profiling of our JBoss AS instance and `SimpleRole#equals`
showed up as a hot method. A lot of time seems to be spent in
`java.lang.Class.cast(Object)`. Switching to a normal Java cast should
fix this since we're inside an `instanceof` and it always succeeds.
- use normal cast in `SimpleRole#equals` instead of
  `java.lang.Class.cast`
- add short circuit case for `this`

Issue: SECURITY-787
https://issues.jboss.org/browse/SECURITY-787
