### PR TITLE
SECURITY-863 LogAuditProvider allocates too much

### DIFF
--- a/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/audit/providers/LogAuditProvider.java
+++ b/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/audit/providers/LogAuditProvider.java
@@ -28,7 +28,11 @@ public class LogAuditProvider extends AbstractAuditProvider
 { 
 
    public void audit(AuditEvent auditEvent)
-   {  
+   {
+      if(!PicketBoxLogger.AUDIT_LOGGER.isTraceEnabled())
+      {
+          return;
+      }
       Exception e = auditEvent.getUnderlyingException();
       if(e != null)
       {


### PR DESCRIPTION
`LogAuditProvider` always logs the `AuditEvent` even if audit logging
is disabled. This means the `AuditEvent` is always converted to a
`String` even if the trace log level is disabled. The profiled our
application and this causes a lot of allocations outside of TLABs for
us even though we have audit logging disabled.
- don't log if the trace level is disabled

Issue: SECURITY-863
https://issues.jboss.org/browse/SECURITY-863
