### PR TITLE
Remove getClassLoader() call from the fast path

### DIFF
--- a/security-spi/spi/src/main/java/org/jboss/security/SecurityContextFactory.java
+++ b/security-spi/spi/src/main/java/org/jboss/security/SecurityContextFactory.java
@@ -266,7 +266,19 @@ public class SecurityContextFactory
     */
    public static SecurityContextUtil createUtil(SecurityContext sc) throws Exception
    {
-      return createUtil(sc, SecuritySPIActions.getCurrentClassLoader(SecurityContextFactory.class));
+       SecurityManager sm = System.getSecurityManager();
+       if (sm != null) {
+           sm.checkPermission(new RuntimePermission(SecurityContextFactory.class.getName() + ".createUtil"));
+       }
+       Constructor<SecurityContextUtil> ctr = defaultUtilConstructor;
+
+       if(ctr == null)
+       {
+           Class<? extends SecurityContextUtil> clazz = (Class<? extends SecurityContextUtil>) loadClass(defaultUtilClassFQN,  SecuritySPIActions.getCurrentClassLoader(SecurityContextFactory.class));
+           defaultUtilClass = clazz;
+           ctr = defaultUtilConstructor = (Constructor<SecurityContextUtil>) clazz.getConstructor(CONTEXT_UTIL_CONSTRUCTOR_TYPES);
+       }
+       return ctr.newInstance(sc);
    }
    
    /**


### PR DESCRIPTION
SecuritySPIActions.getCurrentClassLoader(SecurityContextFactory.class)) is relatively slow, and does not need to be called after the constructor has been created the first time
