### PR TITLE
Fix JDK7/8 compatibility issues

### DIFF
--- a/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/cache/JBossAuthenticationCache.java
+++ b/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/cache/JBossAuthenticationCache.java
@@ -25,6 +25,7 @@ import java.security.Principal;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import javax.security.auth.Subject;
 
@@ -49,7 +50,7 @@ public class JBossAuthenticationCache implements SecurityCache<Principal>
    /** Concurrency Level hint to the concurrent hashmap **/
    private int concurrencyLevel = 16; 
    
-   private ConcurrentHashMap<Principal,AuthCacheObject> cacheMap = null; 
+   private ConcurrentMap<Principal,AuthCacheObject> cacheMap = null;
    
    public JBossAuthenticationCache()
    { 

--- a/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/jacc/DelegatingPolicy.java
+++ b/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/jacc/DelegatingPolicy.java
@@ -28,6 +28,7 @@ import java.security.*;
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * A JAAC Policy provider implementation that delegates any non-JACC permissions
@@ -48,12 +49,12 @@ public class DelegatingPolicy extends Policy
     * Map<String, ContextPolicy> for the JACC context IDs that have been
     * committed.
     */
-   private ConcurrentHashMap<String,ContextPolicy> activePolicies = new ConcurrentHashMap<String,ContextPolicy>();
+   private ConcurrentMap<String,ContextPolicy> activePolicies = new ConcurrentHashMap<String,ContextPolicy>();
    /**
     * Map<String, ContextPolicy> for the JACC policies that are in the open
     * state and should be excluded from the active permission set.
     */ 
-   private ConcurrentHashMap<String,ContextPolicy> openPolicies = new ConcurrentHashMap<String,ContextPolicy>(); 
+   private ConcurrentMap<String,ContextPolicy> openPolicies = new ConcurrentHashMap<String,ContextPolicy>();
    /**
     * The Policy proxy returned via the PolicyProxy attribute
     */

--- a/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/jacc/JBossPolicyConfigurationFactory.java
+++ b/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/jacc/JBossPolicyConfigurationFactory.java
@@ -24,6 +24,7 @@ package org.jboss.security.jacc;
 import java.net.URL;
 import java.security.Policy;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import javax.security.jacc.PolicyConfiguration;
 import javax.security.jacc.PolicyConfigurationFactory;
@@ -41,7 +42,7 @@ import org.jboss.security.util.state.xml.StateMachineParser;
 public class JBossPolicyConfigurationFactory extends PolicyConfigurationFactory
 {
    private StateMachine configStateMachine;
-   private ConcurrentHashMap<String,JBossPolicyConfiguration> policyConfigMap 
+   private ConcurrentMap<String,JBossPolicyConfiguration> policyConfigMap
                    = new ConcurrentHashMap<String,JBossPolicyConfiguration>();
    private DelegatingPolicy policy;
 

--- a/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/plugins/audit/JBossAuditManager.java
+++ b/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/plugins/audit/JBossAuditManager.java
@@ -10,6 +10,7 @@ import java.security.PrivilegedActionException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import org.jboss.security.PicketBoxLogger;
 import org.jboss.security.SecurityUtil;
@@ -33,7 +34,7 @@ import org.jboss.security.plugins.ClassLoaderLocatorFactory;
  */ 
 public class JBossAuditManager implements AuditManager
 {
-   private static ConcurrentHashMap<String,AuditContext> contexts = new ConcurrentHashMap<String,AuditContext>();
+   private static ConcurrentMap<String,AuditContext> contexts = new ConcurrentHashMap<String,AuditContext>();
    
    private static AuditContext defaultContext = null;
    


### PR DESCRIPTION
The latest Picketbox release is broken for use with JDK7 (which obviously affects Wildfly JDK7 support). 

The underlying issue is that the signature of ConcurrentHashMap.keySet() was changed in JDK8 to return a subclass of Set. This means that if code that call ConcurrentHashMap.keySet() is compiled with a JDK8 compiler it will end up with references to a JDK8 only method in the constant pool. If the code is compiled with a JDK7 compiler it will work as normal.

Unfortunately the last release was done with JDK8, which means it is not usable with JDK7.

This PR changes all references to ConcurrentHashMap to ConcurrentMap, which should remove the problem, and allow it to be released with any JDK version (although to be safe it is probably best to do the release with 7). 