### PR TITLE
SECURITY-887 Add Guards Around Debug Statements

### DIFF
--- a/picketbox-infinispan/src/main/java/org/jboss/security/authentication/JBossCachedAuthenticationManager.java
+++ b/picketbox-infinispan/src/main/java/org/jboss/security/authentication/JBossCachedAuthenticationManager.java
@@ -429,7 +429,10 @@ public class JBossCachedAuthenticationManager implements AuthenticationManager, 
       PicketBoxLogger.LOGGER.traceDefaultLoginPrincipal(principal);
       lc = SubjectActions.createLoginContext(securityDomain, subject, theHandler);
       lc.login();
-      PicketBoxLogger.LOGGER.traceDefaultLoginSubject(lc.toString(), SubjectActions.toString(subject));
+      if (PicketBoxLogger.LOGGER.isTraceEnabled())
+      {
+         PicketBoxLogger.LOGGER.traceDefaultLoginSubject(lc.toString(), SubjectActions.toString(subject));
+      }
       return lc;
    }
 
@@ -468,7 +471,10 @@ public class JBossCachedAuthenticationManager implements AuthenticationManager, 
             });
        }
         info.contextClassLoader = lcClassLoader;
-      PicketBoxLogger.LOGGER.traceUpdateCache(SubjectActions.toString(subject), SubjectActions.toString(info.subject));
+      if (PicketBoxLogger.LOGGER.isTraceEnabled())
+      {
+         PicketBoxLogger.LOGGER.traceUpdateCache(SubjectActions.toString(subject), SubjectActions.toString(info.subject));
+      }
 
       // Get the Subject callerPrincipal by looking for a Group called 'CallerPrincipal'
       Set<Group> subjectGroups = subject.getPrincipals(Group.class);
@@ -508,7 +514,11 @@ public class JBossCachedAuthenticationManager implements AuthenticationManager, 
       // only one is allowed so remove the old and insert the new
       domainCache.put(principal != null ? principal : new org.jboss.security.SimplePrincipal("null"), info);
       validatedDomainInfo.set(new CompoundInfo(principal != null ? principal : new org.jboss.security.SimplePrincipal("null"), info));
-      PicketBoxLogger.LOGGER.traceInsertedCacheInfo(info.toString());
+      if (PicketBoxLogger.LOGGER.isTraceEnabled())
+      {
+         PicketBoxLogger.LOGGER.traceInsertedCacheInfo(info.toString());
+      }
+
       return info.subject;
    }
     /**
@@ -568,7 +578,10 @@ public class JBossCachedAuthenticationManager implements AuthenticationManager, 
 
        // if a cache is active, remove the principal from the cache and try to perform the logout using the cached context.
        if (domainCache != null && principal != null) {
-           PicketBoxLogger.LOGGER.traceFlushCacheEntry(principal.getName());
+           if (PicketBoxLogger.LOGGER.isTraceEnabled())
+           {
+              PicketBoxLogger.LOGGER.traceFlushCacheEntry(principal.getName());
+           }
            DomainInfo info = domainCache.get(principal);
            domainCache.remove(principal);
            if (info != null && info.loginContext != null) {
@@ -601,7 +614,10 @@ public class JBossCachedAuthenticationManager implements AuthenticationManager, 
        // perform the JAAS logout.
        try {
            context.logout();
-           PicketBoxLogger.LOGGER.traceLogoutSubject(context.toString(), SubjectActions.toString(subject));
+           if (PicketBoxLogger.LOGGER.isTraceEnabled())
+           {
+              PicketBoxLogger.LOGGER.traceLogoutSubject(context.toString(), SubjectActions.toString(subject));
+           }
        }
        catch (LoginException le) {
            SubjectActions.setContextInfo("org.jboss.security.exception", le);

--- a/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/authorization/modules/ejb/EJBPolicyModuleDelegate.java
+++ b/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/authorization/modules/ejb/EJBPolicyModuleDelegate.java
@@ -126,11 +126,17 @@ public class EJBPolicyModuleDelegate extends AuthorizationModuleDelegate
        //Get the method permissions
       if (methodRoles == null)
       {
-         String method = this.ejbMethod.getName();
-         PicketBoxLogger.LOGGER.traceNoMethodPermissions(method, methodInterface);
+         if (PicketBoxLogger.LOGGER.isTraceEnabled())
+         {
+            String method = this.ejbMethod.getName();
+            PicketBoxLogger.LOGGER.traceNoMethodPermissions(method, methodInterface);
+         }
          return AuthorizationContext.DENY;
       }
-      PicketBoxLogger.LOGGER.debugEJBPolicyModuleDelegateState(ejbMethod.getName(), this.methodInterface, this.methodRoles.toString());
+      if (PicketBoxLogger.LOGGER.isDebugEnabled())
+      {
+         PicketBoxLogger.LOGGER.debugEJBPolicyModuleDelegateState(ejbMethod.getName(), this.methodInterface, this.methodRoles.toString());
+      }
 
       // Check if the caller is allowed to access the method
       if(methodRoles.containsAll(ANYBODY_ROLE) == false)
@@ -156,9 +162,12 @@ public class EJBPolicyModuleDelegate extends AuthorizationModuleDelegate
             if(methodRoles.containsAtleastOneRole(principalRole) == false)
             {
                //Set<Principal> userRoles = am.getUserRoles(ejbPrincipal);
-               String method = this.ejbMethod.getName();
-               PicketBoxLogger.LOGGER.debugInsufficientMethodPermissions(this.ejbPrincipal, this.ejbName, method,
-                       this.methodInterface, this.methodRoles.toString(), principalRole.toString(), null);
+               if (PicketBoxLogger.LOGGER.isDebugEnabled())
+               {
+                  String method = this.ejbMethod.getName();
+                  PicketBoxLogger.LOGGER.debugInsufficientMethodPermissions(this.ejbPrincipal, this.ejbName, method,
+                          this.methodInterface, this.methodRoles.toString(), principalRole.toString(), null);
+               }
                allowed = false;
             } 
          }
@@ -176,8 +185,11 @@ public class EJBPolicyModuleDelegate extends AuthorizationModuleDelegate
                if(srg.containsAtleastOneRole(methodRoles) == false)
                {
                   String method = this.ejbMethod.getName();
-                  PicketBoxLogger.LOGGER.debugInsufficientMethodPermissions(this.ejbPrincipal, this.ejbName, method,
-                          this.methodInterface, this.methodRoles.toString(), null, callerRunAsIdentity.getRunAsRoles().toString());
+                  if (PicketBoxLogger.LOGGER.isDebugEnabled())
+                  {
+                     PicketBoxLogger.LOGGER.debugInsufficientMethodPermissions(this.ejbPrincipal, this.ejbName, method,
+                             this.methodInterface, this.methodRoles.toString(), null, callerRunAsIdentity.getRunAsRoles().toString());
+                  }
                   allowed = false;
                }           
             }


### PR DESCRIPTION
Several debug and trace statements lack guards. This causes unnecessary
method invocation and string allocation if debug logging is off.

 * add guards around debug statements
 * add guards around trace statements

Issue: SECURITY-887
https://issues.jboss.org/browse/SECURITY-887