### PR TITLE
[SECURITY-891] prevent needless calls to LDAP server by getting the r…

### DIFF
--- a/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/auth/spi/LdapExtLoginModule.java
+++ b/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/auth/spi/LdapExtLoginModule.java
@@ -691,7 +691,11 @@ public class LdapExtLoginModule extends UsernamePasswordLoginModule
                String[] attrNames = {roleAttributeID};
                Attributes result = null;
                if (sr.isRelative()) {
-                  result = ldapCtx.getAttributes(quoteDN(dn), attrNames);
+                  // SECURITY-891
+                  result = sr.getAttributes();
+                  if (result.size() == 0) {
+                     result = ldapCtx.getAttributes(quoteDN(dn), attrNames);
+                  }
                }
                else {
                   result = getAttributesFromReferralEntity(sr, user, userDN); 


### PR DESCRIPTION
…equired attributes form the already fetched SearchResult object

https://issues.jboss.org/browse/SECURITY-891
