### PR TITLE
SECURITY-892 Guards Around More Debug Statements

### DIFF
--- a/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/auth/login/XMLLoginConfigImpl.java
+++ b/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/auth/login/XMLLoginConfigImpl.java
@@ -120,7 +120,10 @@ public class XMLLoginConfigImpl extends Configuration implements Serializable, A
    @Override
    public AppConfigurationEntry[] getAppConfigurationEntry(String appName)
    {
-      PicketBoxLogger.LOGGER.traceBeginGetAppConfigEntry(appName, appConfigs.size());
+      if (PicketBoxLogger.LOGGER.isTraceEnabled())
+      {
+         PicketBoxLogger.LOGGER.traceBeginGetAppConfigEntry(appName, appConfigs.size());
+      }
 
       // Load the config if PolicyConfig is empty
       if (this.appConfigs.size() == 0)
@@ -134,7 +137,10 @@ public class XMLLoginConfigImpl extends Configuration implements Serializable, A
 
       if (authInfo == null)
       {
-         PicketBoxLogger.LOGGER.traceGetAppConfigEntryViaParent(appName, parentConfig != null ? parentConfig.toString() : null);
+         if (PicketBoxLogger.LOGGER.isTraceEnabled())
+         {
+            PicketBoxLogger.LOGGER.traceGetAppConfigEntryViaParent(appName, parentConfig != null ? parentConfig.toString() : null);
+         }
          if (parentConfig != null)
             entry = parentConfig.getAppConfigurationEntry(appName);
          if (entry == null)
@@ -147,7 +153,10 @@ public class XMLLoginConfigImpl extends Configuration implements Serializable, A
 
       if (authInfo != null)
       {
-         PicketBoxLogger.LOGGER.traceEndGetAppConfigEntryWithSuccess(appName, authInfo.toString());
+         if (PicketBoxLogger.LOGGER.isTraceEnabled())
+         {
+            PicketBoxLogger.LOGGER.traceEndGetAppConfigEntryWithSuccess(appName, authInfo.toString());
+         }
          // Make a copy of the authInfo object
          final BaseAuthenticationInfo theAuthInfo = authInfo;
          PrivilegedAction<AppConfigurationEntry[]> action = new PrivilegedAction<AppConfigurationEntry[]>()
@@ -237,7 +246,10 @@ public class XMLLoginConfigImpl extends Configuration implements Serializable, A
          sm.checkPermission(REFRESH_PERM);
       AuthenticationInfo authInfo = new AuthenticationInfo(appName);
       authInfo.setAppConfigurationEntry(entries);
-      PicketBoxLogger.LOGGER.traceAddAppConfig(appName, authInfo.toString());
+      if (PicketBoxLogger.LOGGER.isTraceEnabled())
+      {
+         PicketBoxLogger.LOGGER.traceAddAppConfig(appName, authInfo.toString());
+      }
       ApplicationPolicy aPolicy = new ApplicationPolicy(appName, authInfo);
       appConfigs.add(aPolicy);
       SecurityConfiguration.addApplicationPolicy(aPolicy);

--- a/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/auth/spi/BaseCertLoginModule.java
+++ b/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/auth/spi/BaseCertLoginModule.java
@@ -119,13 +119,19 @@ public class BaseCertLoginModule extends AbstractServerLoginModule
          if (tempDomain instanceof SecurityDomain)
          {
             domain = tempDomain;
-            PicketBoxLogger.LOGGER.traceSecurityDomainFound(domain.getClass().getName());
+            if (PicketBoxLogger.LOGGER.isTraceEnabled())
+            {
+               PicketBoxLogger.LOGGER.traceSecurityDomainFound(domain.getClass().getName());
+            }
          }
          else {
             tempDomain = new InitialContext().lookup(SecurityConstants.JAAS_CONTEXT_ROOT + sd + "/jsse");
             if (tempDomain instanceof JSSESecurityDomain) {
                domain = tempDomain;
-               PicketBoxLogger.LOGGER.traceSecurityDomainFound(domain.getClass().getName());
+               if (PicketBoxLogger.LOGGER.isTraceEnabled())
+               {
+                  PicketBoxLogger.LOGGER.traceSecurityDomainFound(domain.getClass().getName());
+               }
             }
             else
             {
@@ -203,7 +209,10 @@ public class BaseCertLoginModule extends AbstractServerLoginModule
       if (alias == null && credential == null)
       {
          identity = unauthenticatedIdentity;
-         PicketBoxLogger.LOGGER.traceUsingUnauthIdentity(identity.toString());
+         if (PicketBoxLogger.LOGGER.isTraceEnabled())
+         {
+            PicketBoxLogger.LOGGER.traceUsingUnauthIdentity(identity.toString());
+         }
       }
 
       if (identity == null)
@@ -303,7 +312,10 @@ public class BaseCertLoginModule extends AbstractServerLoginModule
             if (tmpCert instanceof X509Certificate)
             {
                cert = (X509Certificate) tmpCert;
-               PicketBoxLogger.LOGGER.traceCertificateFound(cert.getSerialNumber().toString(16), cert.getSubjectDN().getName());
+               if (PicketBoxLogger.LOGGER.isTraceEnabled())
+               {
+                  PicketBoxLogger.LOGGER.traceCertificateFound(cert.getSerialNumber().toString(16), cert.getSubjectDN().getName());
+               }
             }
             else if( tmpCert instanceof X509Certificate[] )
             {

--- a/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/auth/spi/LdapLoginModule.java
+++ b/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/auth/spi/LdapLoginModule.java
@@ -361,7 +361,10 @@ public class LdapLoginModule extends UsernamePasswordLoginModule
          if (currentTCCL != null)
             SecurityActions.setContextClassLoader(null);
          ctx = new InitialLdapContext(env, null);
-         PicketBoxLogger.LOGGER.traceSuccessfulLogInToLDAP(ctx.toString());
+         if (PicketBoxLogger.LOGGER.isTraceEnabled())
+         {
+            PicketBoxLogger.LOGGER.traceSuccessfulLogInToLDAP(ctx.toString());
+         }
 
          if (bindDN != null)
          {
@@ -454,8 +457,11 @@ public class LdapLoginModule extends UsernamePasswordLoginModule
                controls.setReturningAttributes(roleAttr);
                controls.setTimeLimit(searchTimeLimit);
                Object[] filterArgs = {userToMatch};
-               PicketBoxLogger.LOGGER.traceRolesDNSearch(rolesCtxDN, roleFilter.toString(), userToMatch,
-                       Arrays.toString(roleAttr), searchScope, searchTimeLimit);
+               if (PicketBoxLogger.LOGGER.isTraceEnabled())
+               {
+                  PicketBoxLogger.LOGGER.traceRolesDNSearch(rolesCtxDN, roleFilter.toString(), userToMatch,
+                          Arrays.toString(roleAttr), searchScope, searchTimeLimit);
+               }
                answer = ctx.search(rolesCtxDN, roleFilter.toString(), filterArgs, controls);
                while (answer.hasMore())
                {

--- a/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/auth/spi/Util.java
+++ b/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/auth/spi/Util.java
@@ -228,13 +228,19 @@ public class Util
           } else {
               throw PicketBoxMessages.MESSAGES.unableToLoadPropertiesFile(propertiesName);
           }
-          PicketBoxLogger.LOGGER.tracePropertiesFileLoaded(propertiesName, bundle.keySet());
+          if (PicketBoxLogger.LOGGER.isTraceEnabled())
+          {
+             PicketBoxLogger.LOGGER.tracePropertiesFileLoaded(propertiesName, bundle.keySet());
+          }
       } else {
           InputStream is = null;
           try {
               is = defaultUrl.openStream();
               bundle.load(is);
-              PicketBoxLogger.LOGGER.tracePropertiesFileLoaded(defaultsName, bundle.keySet());
+              if (PicketBoxLogger.LOGGER.isTraceEnabled())
+              {
+                 PicketBoxLogger.LOGGER.tracePropertiesFileLoaded(defaultsName, bundle.keySet());
+              }
           } catch (Throwable e) {
               PicketBoxLogger.LOGGER.debugFailureToLoadPropertiesFile(defaultsName, e);
           } finally {
@@ -321,7 +327,10 @@ public class Util
          {
             throw PicketBoxMessages.MESSAGES.unableToLoadPropertiesFile(propertiesName);
          }
-         PicketBoxLogger.LOGGER.tracePropertiesFileLoaded(propertiesName, bundle.keySet());
+         if (PicketBoxLogger.LOGGER.isTraceEnabled())
+         {
+            PicketBoxLogger.LOGGER.tracePropertiesFileLoaded(propertiesName, bundle.keySet());
+         }
       }
 
       return bundle;

--- a/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/authorization/modules/ejb/EJBJACCPolicyModuleDelegate.java
+++ b/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/authorization/modules/ejb/EJBJACCPolicyModuleDelegate.java
@@ -109,12 +109,12 @@ public class EJBJACCPolicyModuleDelegate extends AbstractJACCModuleDelegate
     * @param role
     * @return
     */
-   private int process(Subject callerSubject, Role role) 
-   {  
-      EJBMethodPermission methodPerm = 
-         new EJBMethodPermission(ejbName, methodInterface, ejbMethod); 
-      boolean policyDecision = checkWithPolicy(methodPerm, callerSubject, role); 
-      if( policyDecision == false )
+   private int process(Subject callerSubject, Role role)
+   {
+      EJBMethodPermission methodPerm =
+         new EJBMethodPermission(ejbName, methodInterface, ejbMethod);
+      boolean policyDecision = checkWithPolicy(methodPerm, callerSubject, role);
+      if( policyDecision == false && PicketBoxLogger.LOGGER.isDebugEnabled() )
       {
           PicketBoxLogger.LOGGER.debugJACCDeniedAccess(methodPerm.toString(), callerSubject,
                   role != null ? role.toString() : null);
@@ -123,11 +123,11 @@ public class EJBJACCPolicyModuleDelegate extends AbstractJACCModuleDelegate
    }
    
    private int checkRoleRef(Subject callerSubject, RoleGroup callerRoles)
-   { 
-      //This has to be the EJBRoleRefPermission  
-      EJBRoleRefPermission ejbRoleRefPerm = new EJBRoleRefPermission(ejbName,roleName); 
-      boolean policyDecision = checkWithPolicy(ejbRoleRefPerm, callerSubject, callerRoles); 
-      if( policyDecision == false )
+   {
+      //This has to be the EJBRoleRefPermission
+      EJBRoleRefPermission ejbRoleRefPerm = new EJBRoleRefPermission(ejbName,roleName);
+      boolean policyDecision = checkWithPolicy(ejbRoleRefPerm, callerSubject, callerRoles);
+      if( policyDecision == false && PicketBoxLogger.LOGGER.isDebugEnabled() )
       {
          PicketBoxLogger.LOGGER.debugJACCDeniedAccess(ejbRoleRefPerm.toString(), callerSubject,
                  callerRoles != null ? callerRoles.toString() : null);

--- a/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/authorization/modules/web/WebJACCPolicyModuleDelegate.java
+++ b/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/authorization/modules/web/WebJACCPolicyModuleDelegate.java
@@ -193,7 +193,10 @@ public class WebJACCPolicyModuleDelegate extends AbstractJACCModuleDelegate
       WebResourcePermission perm = new WebResourcePermission(this.canonicalRequestURI, 
                                                      request.getMethod());
       boolean allowed = checkPolicy(perm, requestPrincipal, caller, role );
-      PicketBoxLogger.LOGGER.traceHasResourcePermission(perm.toString(), allowed);
+      if (PicketBoxLogger.LOGGER.isTraceEnabled())
+      {
+         PicketBoxLogger.LOGGER.traceHasResourcePermission(perm.toString(), allowed);
+      }
       return allowed;
    }
 
@@ -244,7 +247,10 @@ public class WebJACCPolicyModuleDelegate extends AbstractJACCModuleDelegate
       {
          PicketBoxLogger.LOGGER.debugIgnoredException(e);
       }
-      PicketBoxLogger.LOGGER.traceHasUserDataPermission(perm.toString(), ok);
+      if (PicketBoxLogger.LOGGER.isTraceEnabled())
+      {
+         PicketBoxLogger.LOGGER.traceHasUserDataPermission(perm.toString(), ok);
+      }
       return ok;
    }
 

--- a/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/config/StandaloneConfiguration.java
+++ b/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/config/StandaloneConfiguration.java
@@ -116,7 +116,10 @@ public class StandaloneConfiguration extends Configuration implements Applicatio
 
       if (authInfo == null)
       {
-          PicketBoxLogger.LOGGER.traceGetAppConfigEntryViaParent(appName, parentConfig != null ? parentConfig.toString() : null);
+         if (PicketBoxLogger.LOGGER.isTraceEnabled())
+         {
+            PicketBoxLogger.LOGGER.traceGetAppConfigEntryViaParent(appName, parentConfig != null ? parentConfig.toString() : null);
+         }
          if (parentConfig != null)
             entry = parentConfig.getAppConfigurationEntry(appName);
          if (entry == null)
@@ -129,7 +132,10 @@ public class StandaloneConfiguration extends Configuration implements Applicatio
 
       if (authInfo != null)
       {
-         PicketBoxLogger.LOGGER.traceEndGetAppConfigEntryWithSuccess(appName, authInfo.toString());
+         if (PicketBoxLogger.LOGGER.isTraceEnabled())
+         {
+            PicketBoxLogger.LOGGER.traceEndGetAppConfigEntryWithSuccess(appName, authInfo.toString());
+         }
          // Make a copy of the authInfo object
          final BaseAuthenticationInfo theAuthInfo = authInfo;
          PrivilegedAction<AppConfigurationEntry[]> action = new PrivilegedAction<AppConfigurationEntry[]>()

--- a/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/identitytrust/JBossIdentityTrustContext.java
+++ b/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/identitytrust/JBossIdentityTrustContext.java
@@ -199,7 +199,10 @@ public class JBossIdentityTrustContext extends IdentityTrustContext
          //REQUISITE case
          if(flag == ControlFlag.REQUISITE)
          {
-            PicketBoxLogger.LOGGER.debugRequisiteModuleFailure(module.getClass().getName());
+            if (PicketBoxLogger.LOGGER.isDebugEnabled())
+            {
+               PicketBoxLogger.LOGGER.debugRequisiteModuleFailure(module.getClass().getName());
+            }
             if(moduleException == null)
                moduleException = new IdentityTrustException(PicketBoxMessages.MESSAGES.identityTrustValidationFailedMessage());
             else
@@ -208,7 +211,10 @@ public class JBossIdentityTrustContext extends IdentityTrustContext
          //REQUIRED Case
          if(flag == ControlFlag.REQUIRED)
          {
-             PicketBoxLogger.LOGGER.debugRequiredModuleFailure(module.getClass().getName());
+             if (PicketBoxLogger.LOGGER.isDebugEnabled())
+             {
+                PicketBoxLogger.LOGGER.debugRequiredModuleFailure(module.getClass().getName());
+             }
              encounteredRequiredDeny = true;
          }
          if(flag == ControlFlag.OPTIONAL)

--- a/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/jacc/JBossPolicyConfiguration.java
+++ b/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/jacc/JBossPolicyConfiguration.java
@@ -157,7 +157,10 @@ public class JBossPolicyConfiguration implements PolicyConfiguration
    public void linkConfiguration(PolicyConfiguration link)
       throws PolicyContextException
    {
-      PicketBoxLogger.LOGGER.traceLinkConfiguration(link.getContextID());
+      if (PicketBoxLogger.LOGGER.isTraceEnabled())
+      {
+         PicketBoxLogger.LOGGER.traceLinkConfiguration(link.getContextID());
+      }
       validateState("linkConfiguration");
       policy.linkConfiguration(contextID, link);
    }

--- a/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/mapping/providers/role/Util.java
+++ b/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/mapping/providers/role/Util.java
@@ -124,7 +124,10 @@ public class Util
       {
          throw PicketBoxMessages.MESSAGES.unableToLoadPropertiesFile(propertiesName);
       }
-      PicketBoxLogger.LOGGER.tracePropertiesFileLoaded(propertiesName, bundle.keySet());
+      if (PicketBoxLogger.LOGGER.isTraceEnabled())
+      {
+         PicketBoxLogger.LOGGER.tracePropertiesFileLoaded(propertiesName, bundle.keySet());
+      }
 
       return bundle;
    }

--- a/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/plugins/HostThreadLocal.java
+++ b/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/plugins/HostThreadLocal.java
@@ -36,13 +36,19 @@ public class HostThreadLocal
    public static String get() 
    {
       String hostName = host.get();
-      PicketBoxLogger.LOGGER.traceHostThreadLocalGet(hostName, Thread.currentThread().getId());
+      if (PicketBoxLogger.LOGGER.isTraceEnabled())
+      {
+         PicketBoxLogger.LOGGER.traceHostThreadLocalGet(hostName, Thread.currentThread().getId());
+      }
       return hostName;
    }
 
    public static void set(String hostVal) 
    {
-      PicketBoxLogger.LOGGER.traceHostThreadLocalSet(hostVal, Thread.currentThread().getId());
+      if (PicketBoxLogger.LOGGER.isTraceEnabled())
+      {
+         PicketBoxLogger.LOGGER.traceHostThreadLocalSet(hostVal, Thread.currentThread().getId());
+      }
       host.set(hostVal);
    }
 

--- a/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/plugins/JBossAuthorizationManager.java
+++ b/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/plugins/JBossAuthorizationManager.java
@@ -146,7 +146,10 @@ implements AuthorizationManager
    {
       boolean hasRole = false;
       RoleGroup roles = this.getCurrentRoles(principal);
-      PicketBoxLogger.LOGGER.traceBeginDoesUserHaveRole(principal, roles != null ? roles.toString() : "");
+      if (PicketBoxLogger.LOGGER.isTraceEnabled())
+      {
+         PicketBoxLogger.LOGGER.traceBeginDoesUserHaveRole(principal, roles != null ? roles.toString() : "");
+      }
       if(roles != null)
       {
          Iterator<Principal> iter = rolePrincipals.iterator();
@@ -378,14 +381,20 @@ implements AuthorizationManager
             
             //Append the principals also
             contextMap.put(SecurityConstants.PRINCIPALS_SET_IDENTIFIER, subject.getPrincipals());
-            PicketBoxLogger.LOGGER.traceRolesBeforeMapping(userRoles != null ? userRoles.toString() : "");
+            if (PicketBoxLogger.LOGGER.isTraceEnabled())
+            {
+               PicketBoxLogger.LOGGER.traceRolesBeforeMapping(userRoles != null ? userRoles.toString() : "");
+            }
 
             if(userRoles == null)
                userRoles = this.getEmptyRoleGroup();
             
             mc.performMapping(contextMap, userRoles);
             mappedUserRoles = mc.getMappingResult().getMappedObject();
-            PicketBoxLogger.LOGGER.traceRolesAfterMapping(userRoles.toString());
+            if (PicketBoxLogger.LOGGER.isTraceEnabled())
+            {
+               PicketBoxLogger.LOGGER.traceRolesAfterMapping(userRoles.toString());
+            }
          }
          securityContext.getData().put(ROLES_IDENTIFIER, mappedUserRoles);
       } 

--- a/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/plugins/JBossPolicyRegistration.java
+++ b/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/plugins/JBossPolicyRegistration.java
@@ -90,7 +90,10 @@ public class JBossPolicyRegistration implements PolicyRegistration, Serializable
       InputStream is = null;
       try
       {
-         PicketBoxLogger.LOGGER.traceRegisterPolicy(contextID, type, location != null ? location.getPath() : null);
+         if (PicketBoxLogger.LOGGER.isTraceEnabled())
+         {
+            PicketBoxLogger.LOGGER.traceRegisterPolicy(contextID, type, location != null ? location.getPath() : null);
+         }
          is = location.openStream();
          registerPolicy(contextID, type, is);
       }

--- a/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/plugins/auth/JaasSecurityManagerBase.java
+++ b/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/plugins/auth/JaasSecurityManagerBase.java
@@ -386,7 +386,10 @@ public class JaasSecurityManagerBase
       PicketBoxLogger.LOGGER.traceDefaultLoginPrincipal(principal);
       lc = SubjectActions.createLoginContext(securityDomain, subject, theHandler);
       lc.login();
-      PicketBoxLogger.LOGGER.traceDefaultLoginSubject(lc.toString(), SubjectActions.toString(subject));
+      if (PicketBoxLogger.LOGGER.isDebugEnabled())
+      {
+         PicketBoxLogger.LOGGER.traceDefaultLoginSubject(lc.toString(), SubjectActions.toString(subject));
+      }
       return lc;
    }
 
@@ -424,7 +427,10 @@ public class JaasSecurityManagerBase
         // perform the JAAS logout.
         try {
             context.logout();
-            PicketBoxLogger.LOGGER.traceLogoutSubject(context.toString(), SubjectActions.toString(subject));
+            if (PicketBoxLogger.LOGGER.isTraceEnabled())
+            {
+               PicketBoxLogger.LOGGER.traceLogoutSubject(context.toString(), SubjectActions.toString(subject));
+            }
         }
         catch (LoginException le) {
             SubjectActions.setContextInfo("org.jboss.security.exception", le);

--- a/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/plugins/authorization/JBossAuthorizationContext.java
+++ b/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/plugins/authorization/JBossAuthorizationContext.java
@@ -245,7 +245,10 @@ public class JBossAuthorizationContext extends AuthorizationContext
          //REQUISITE case
          if (flag == ControlFlag.REQUISITE)
          {
-            PicketBoxLogger.LOGGER.debugRequisiteModuleFailure(module.getClass().getName());
+            if (PicketBoxLogger.LOGGER.isDebugEnabled())
+            {
+               PicketBoxLogger.LOGGER.debugRequisiteModuleFailure(module.getClass().getName());
+            }
             if (moduleException == null)
                moduleException = new AuthorizationException(PicketBoxMessages.MESSAGES.authorizationFailedMessage());
             else
@@ -254,7 +257,10 @@ public class JBossAuthorizationContext extends AuthorizationContext
          //REQUIRED Case
          if (flag == ControlFlag.REQUIRED)
          {
-            PicketBoxLogger.LOGGER.debugRequiredModuleFailure(module.getClass().getName());
+            if (PicketBoxLogger.LOGGER.isDebugEnabled())
+            {
+               PicketBoxLogger.LOGGER.debugRequiredModuleFailure(module.getClass().getName());
+            }
             if (encounteredRequiredError == false)
                encounteredRequiredError = true;
          }

--- a/security-jboss-sx/jbosssx/src/main/java/org/picketbox/datasource/security/CallerIdentityLoginModule.java
+++ b/security-jboss-sx/jbosssx/src/main/java/org/picketbox/datasource/security/CallerIdentityLoginModule.java
@@ -163,7 +163,10 @@ public class CallerIdentityLoginModule
          if (user != null)
          {
             username = user.getName();
-            PicketBoxLogger.LOGGER.traceCurrentCallingPrincipal(username, Thread.currentThread().getName());
+            if (PicketBoxLogger.LOGGER.isTraceEnabled())
+            {
+               PicketBoxLogger.LOGGER.traceCurrentCallingPrincipal(username, Thread.currentThread().getName());
+            }
 
             // Check for a RunAsIdentity
             RunAsIdentity runAs = GetPrincipalInfoAction.peekRunAsIdentity();


### PR DESCRIPTION
Several debug and trace statements lack guards. This causes unnecessary
method invocation and string allocation if debug logging is off. We
left out guards for very simple getters.

Issue: SECURITY-892
https://issues.jboss.org/browse/SECURITY-892