### PR TITLE
Pass options to ServerAuthModule

### DIFF
--- a/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/auth/message/config/JBossServerAuthConfig.java
+++ b/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/auth/message/config/JBossServerAuthConfig.java
@@ -160,6 +160,7 @@ public class JBossServerAuthConfig implements ServerAuthConfig
                   
                   Map options = new HashMap();
                   
+                  options.putAll(ame.getOptions());
                   sam.initialize(null, null, callbackHandler, options);
                   modules.add(sam);
                }
@@ -177,6 +178,7 @@ public class JBossServerAuthConfig implements ServerAuthConfig
                   ServerAuthModule sam = this.createSAM(moduleCL, ame.getAuthModuleName());
                   
                   Map options = new HashMap(); 
+                  options.putAll(ame.getOptions());
                   sam.initialize(null, null, callbackHandler, options);
                   modules.add(sam);
                }


### PR DESCRIPTION
Pass the configured auth module entry options to the
server auth module so the SAM can be configured.