### PR TITLE
Delete <include> of EULA files in POM files

### DIFF
--- a/security-jboss-sx/jbosssx-client/pom.xml
+++ b/security-jboss-sx/jbosssx-client/pom.xml
@@ -34,7 +34,6 @@
           </archive>
           <classesDirectory>../jbosssx/target/classes</classesDirectory>
           <includes>
-             <include>JBossORG-EULA.txt</include>
              <include>org/jboss/crypto/JBossSXProvider.class</include>
              <include>org/jboss/crypto/CryptoUtil.class</include>
              <include>org/jboss/crypto/digest/*</include>

--- a/security-jboss-sx/jbosssx/pom.xml
+++ b/security-jboss-sx/jbosssx/pom.xml
@@ -73,12 +73,6 @@
                 </includes>
             </resource>
             <resource>
-                <directory>${basedir}</directory>
-                <includes>
-                    <include>JBossORG-EULA.txt</include>
-                </includes>
-            </resource>
-            <resource>
                 <directory>src/main/resources</directory>
                 <includes>
                     <include>**/*.dtd</include>


### PR DESCRIPTION
Sorry if I'm not mistaken I ought to have done these changes in my previous pull request - given the removal of the EULA files the <include> elements referencing them should also be removed.