### PR TITLE
SECURITY-913: NPE if use LdapExtLoginModule in j2se

### DIFF
--- a/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/config/parser/ApplicationPolicyParser.java
+++ b/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/config/parser/ApplicationPolicyParser.java
@@ -120,7 +120,7 @@ public class ApplicationPolicyParser implements XMLStreamConstants
             xmlEvent = xmlEventReader.nextEvent();
             AuthenticationConfigParser parser = new AuthenticationConfigParser();
             Set<AppConfigurationEntry> entries = parser.parse(xmlEventReader);
-            AuthenticationInfo authInfo = new AuthenticationInfo();
+            AuthenticationInfo authInfo = new AuthenticationInfo(appPolicy.getName());
              
             authInfo.setAppConfigurationEntry(new ArrayList(entries));
             appPolicy.setAuthenticationInfo(authInfo); 


### PR DESCRIPTION
```
new AuthenticationInfo()
```

 will cause `jboss.security.security_domain=null` be passed to LdapExtLoginModule, which this cause NPE, if change to 

```
new AuthenticationInfo(appPolicy.getName());
```

will resolve the issue
