### PR TITLE
Bump minor version to be ready for next WF/EAP release

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.picketbox</groupId>
         <artifactId>picketbox-parent</artifactId>
-        <version>5.0.3.Beta2-SNAPSHOT</version>
+        <version>5.1.0.Beta1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>picketbox</artifactId>

--- a/picketbox-infinispan/pom.xml
+++ b/picketbox-infinispan/pom.xml
@@ -2,14 +2,14 @@
     <parent>
         <groupId>org.picketbox</groupId>
         <artifactId>picketbox-parent</artifactId>
-        <version>5.0.3.Beta2-SNAPSHOT</version>
+        <version>5.1.0.Beta1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.picketbox</groupId>
     <artifactId>picketbox-infinispan</artifactId>
-    <version>5.0.3.Beta2-SNAPSHOT</version>
+    <version>5.1.0.Beta1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Picketbox Infinispan</name>
     <url>http://jboss.org/picketbox</url>

--- a/picketbox/pom.xml
+++ b/picketbox/pom.xml
@@ -2,14 +2,14 @@
     <parent>
         <groupId>org.picketbox</groupId>
         <artifactId>picketbox-parent</artifactId>
-        <version>5.0.3.Beta2-SNAPSHOT</version>
+        <version>5.1.0.Beta1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.picketbox</groupId>
     <artifactId>picketbox-bare</artifactId>
-    <version>5.0.3.Beta2-SNAPSHOT</version>
+    <version>5.1.0.Beta1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Picketbox</name>
     <url>http://jboss.org/picketbox</url>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <name>PicketBox- Parent</name>
     <url>http://jboss.org/picketbox</url>
     <description>PicketBox is a security framework for authentication, authorization, audit and mapping</description>
-    <version>5.0.3.Beta2-SNAPSHOT</version>
+    <version>5.1.0.Beta1-SNAPSHOT</version>
 
     <licenses>
         <license>

--- a/security-jboss-sx/acl/pom.xml
+++ b/security-jboss-sx/acl/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.picketbox</groupId>
         <artifactId>jbosssx-pom</artifactId>
-        <version>5.0.3.Beta2-SNAPSHOT</version>
+        <version>5.1.0.Beta1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/security-jboss-sx/dist/pom.xml
+++ b/security-jboss-sx/dist/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.picketbox</groupId>
         <artifactId>jbosssx-pom</artifactId>
-        <version>5.0.3.Beta2-SNAPSHOT</version>
+        <version>5.1.0.Beta1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/security-jboss-sx/identity/pom.xml
+++ b/security-jboss-sx/identity/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.picketbox</groupId>
         <artifactId>jbosssx-pom</artifactId>
-        <version>5.0.3.Beta2-SNAPSHOT</version>
+        <version>5.1.0.Beta1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/security-jboss-sx/jbosssx-client/pom.xml
+++ b/security-jboss-sx/jbosssx-client/pom.xml
@@ -2,13 +2,13 @@
     <parent>
         <groupId>org.picketbox</groupId>
         <artifactId>jbosssx-pom</artifactId>
-        <version>5.0.3.Beta2-SNAPSHOT</version>
+        <version>5.1.0.Beta1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.picketbox</groupId>
     <artifactId>jbosssx-client</artifactId>
-    <version>5.0.3.Beta2-SNAPSHOT</version>
+    <version>5.1.0.Beta1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>PicketBox Client</name>
     <url>http://www.jboss.org/picketbox</url>

--- a/security-jboss-sx/jbosssx/pom.xml
+++ b/security-jboss-sx/jbosssx/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.picketbox</groupId>
         <artifactId>jbosssx-pom</artifactId>
-        <version>5.0.3.Beta2-SNAPSHOT</version>
+        <version>5.1.0.Beta1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/security-jboss-sx/pom.xml
+++ b/security-jboss-sx/pom.xml
@@ -2,13 +2,13 @@
     <parent>
         <groupId>org.picketbox</groupId>
         <artifactId>picketbox-parent</artifactId>
-        <version>5.0.3.Beta2-SNAPSHOT</version>
+        <version>5.1.0.Beta1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.picketbox</groupId>
     <artifactId>jbosssx-pom</artifactId>
-    <version>5.0.3.Beta2-SNAPSHOT</version>
+    <version>5.1.0.Beta1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>PicketBox Implementation - Aggregator</name>
     <url>http://jboss.org/picketbox</url>

--- a/security-spi/acl/pom.xml
+++ b/security-spi/acl/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.picketbox</groupId>
         <artifactId>picketbox-spi-pom</artifactId>
-        <version>5.0.3.Beta2-SNAPSHOT</version>
+        <version>5.1.0.Beta1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/security-spi/authorization/pom.xml
+++ b/security-spi/authorization/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.picketbox</groupId>
         <artifactId>picketbox-spi-pom</artifactId>
-        <version>5.0.3.Beta2-SNAPSHOT</version>
+        <version>5.1.0.Beta1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/security-spi/common/pom.xml
+++ b/security-spi/common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.picketbox</groupId>
         <artifactId>picketbox-spi-pom</artifactId>
-        <version>5.0.3.Beta2-SNAPSHOT</version>
+        <version>5.1.0.Beta1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/security-spi/dist/pom.xml
+++ b/security-spi/dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.picketbox</groupId>
         <artifactId>picketbox-spi-pom</artifactId>
-        <version>5.0.3.Beta2-SNAPSHOT</version>
+        <version>5.1.0.Beta1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>jboss-security-spi</artifactId>

--- a/security-spi/identity/pom.xml
+++ b/security-spi/identity/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.picketbox</groupId>
         <artifactId>picketbox-spi-pom</artifactId>
-        <version>5.0.3.Beta2-SNAPSHOT</version>
+        <version>5.1.0.Beta1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/security-spi/pom.xml
+++ b/security-spi/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.picketbox</groupId>
         <artifactId>picketbox-parent</artifactId>
-        <version>5.0.3.Beta2-SNAPSHOT</version>
+        <version>5.1.0.Beta1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/security-spi/spi/pom.xml
+++ b/security-spi/spi/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.picketbox</groupId>
         <artifactId>picketbox-spi-pom</artifactId>
-        <version>5.0.3.Beta2-SNAPSHOT</version>
+        <version>5.1.0.Beta1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
We need to maintain versioning scheme for product component as 5.0.z.Final.