### PR TITLE
SECURITY-992: org.jboss.security.Base64Encoder doesn't work for certain lengths (1026 or 3072 for example)

### DIFF
--- a/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/Base64Encoder.java
+++ b/security-jboss-sx/jbosssx/src/main/java/org/jboss/security/Base64Encoder.java
@@ -164,6 +164,46 @@ public final class Base64Encoder
       return buf[off+2] & 0x3f ;
    }
 
+   private static int writeValues(OutputStream out, int count, int c1, byte c2, byte c3, byte c4) throws IOException {
+       switch (count)
+       {
+           case 73:
+              out.write(c1);
+              out.write(c2);
+              out.write(c3);
+              out.write('\n');
+              out.write(c4);
+              return 1;
+            case 74:
+              out.write(c1);
+              out.write(c2);
+              out.write('\n');
+              out.write(c3);
+              out.write(c4);
+              return 2 ;
+            case 75:
+              out.write(c1);
+              out.write('\n');
+              out.write(c2);
+              out.write(c3);
+              out.write(c4);
+              return 3 ;
+            case 76:
+              out.write('\n');
+              out.write(c1);
+              out.write(c2);
+              out.write(c3);
+              out.write(c4);
+              return 4;
+            default:
+              out.write(c1);
+              out.write(c2);
+              out.write(c3);
+              out.write(c4);
+              return count + 4;
+       }
+   }
+
   /**
    * Process the data: encode the input stream to the output stream.
    * This method runs through the input stream, encoding it to the output
@@ -179,7 +219,7 @@ public final class Base64Encoder
       int  count    = 0 ;
       while ((got = in.read(buffer, off, BUFFER_SIZE-off)) > 0)
       {
-         if ( got >= 3 )
+         if ( got + off >= 3 )
          {
             got += off;
             off  = 0;
@@ -189,48 +229,7 @@ public final class Base64Encoder
                 int c2 = get2(buffer,off);
                 int c3 = get3(buffer,off);
                 int c4 = get4(buffer,off);
-                switch (count)
-                {
-                    case 73:
-                       out.write(encoding[c1]);
-                       out.write(encoding[c2]);
-                       out.write(encoding[c3]);
-                       out.write ('\n') ;
-                       out.write(encoding[c4]);
-                       count = 1 ;
-                       break ;
-                     case 74:
-                       out.write(encoding[c1]);
-                       out.write(encoding[c2]);
-                       out.write ('\n') ;
-                       out.write(encoding[c3]);
-                       out.write(encoding[c4]) ;
-                       count = 2 ;
-                       break ;
-                     case 75:
-                       out.write(encoding[c1]);
-                       out.write ('\n') ;
-                       out.write(encoding[c2]);
-                       out.write(encoding[c3]);
-                       out.write(encoding[c4]) ;
-                       count = 3 ;
-                       break ;
-                     case 76:
-                       out.write('\n') ;
-                       out.write(encoding[c1]);
-                       out.write(encoding[c2]);
-                       out.write(encoding[c3]);
-                       out.write(encoding[c4]);
-                       count = 4;
-                       break;
-                     default:
-                       out.write(encoding[c1]);
-                       out.write(encoding[c2]);
-                       out.write(encoding[c3]);
-                       out.write(encoding[c4]);
-                       count += 4;
-                       break;
-                }
+                count = writeValues(out, count, encoding[c1], encoding[c2], encoding[c3], encoding[c4]);
                 off += 3;
             }
             // Copy remaining bytes to beginning of buffer:
@@ -247,18 +246,11 @@ public final class Base64Encoder
       // Manage the last bytes, from 0 to off:
       switch (off) {
         case 1:
-            out.write(encoding[get1(buffer, 0)]);
-            out.write(encoding[get2(buffer, 0)]);
-            out.write('=');
-            out.write('=');
+            writeValues(out, count, encoding[get1(buffer, 0)], encoding[get2(buffer, 0)], (byte) '=', (byte) '=');
             break ;
         case 2:
-            out.write(encoding[get1(buffer, 0)]);
-            out.write(encoding[get2(buffer, 0)]);
-            out.write(encoding[get3(buffer, 0)]);
-            out.write('=');
+            writeValues(out, count, encoding[get1(buffer, 0)], encoding[get2(buffer, 0)], encoding[get3(buffer, 0)], (byte) '=');
       }
       return;
    }
 }
-

--- a/security-jboss-sx/jbosssx/src/test/java/org/jboss/test/security/helpers/Base64UnitTestCase.java
+++ b/security-jboss-sx/jbosssx/src/test/java/org/jboss/test/security/helpers/Base64UnitTestCase.java
@@ -1,0 +1,127 @@
+/*
+  * JBoss, Home of Professional Open Source
+  * Copyright 2007, JBoss Inc., and individual contributors as indicated
+  * by the @authors tag. See the copyright.txt in the distribution for a
+  * full listing of individual contributors.
+  *
+  * This is free software; you can redistribute it and/or modify it
+  * under the terms of the GNU Lesser General Public License as
+  * published by the Free Software Foundation; either version 2.1 of
+  * the License, or (at your option) any later version.
+  *
+  * This software is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  * Lesser General Public License for more details.
+  *
+  * You should have received a copy of the GNU Lesser General Public
+  * License along with this software; if not, write to the Free
+  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  */
+package org.jboss.test.security.helpers;
+
+import java.util.Arrays;
+import java.util.Random;
+import javax.xml.bind.DatatypeConverter;
+import junit.framework.TestCase;
+import org.jboss.security.Base64Encoder;
+
+/**
+ *
+ * @author rmartinc
+ */
+public class Base64UnitTestCase extends TestCase {
+    
+    private final Random rand;
+    
+    public Base64UnitTestCase() {
+        rand = new Random();
+    }
+    
+    private byte[] generateRandonByteArray(int length) {
+        byte[] result = new byte[length];
+        rand.nextBytes(result);
+        return result;
+    }
+    
+    private void testEOLLine(String message, String base64) {
+        for (int i = 76; i < base64.length(); i += 77) {
+            assertTrue(message + " pos " + i, base64.charAt(i) == '\n');
+        }
+    }
+    
+    private void internalTest(String message, int length) throws Exception{
+        byte[] orig = generateRandonByteArray(length);
+        String encoded = Base64Encoder.encode(orig);
+        testEOLLine(message, encoded);
+        String encoded2 = DatatypeConverter.printBase64Binary(orig);
+        assertEquals(message, encoded.replace("\n", ""), encoded2);
+        byte[] decoded = DatatypeConverter.parseBase64Binary(encoded);
+        assertTrue(message, Arrays.equals(orig, decoded));
+    }
+    
+    // test for 1-4 size
+    
+    public void test1() throws Exception {
+        internalTest("size1", 1);
+    }
+    
+    public void test2() throws Exception {
+        internalTest("size2", 2);
+    }
+    
+    public void test3() throws Exception {
+        internalTest("size3", 3);
+    }
+    
+    public void test4() throws Exception {
+        internalTest("size4", 4);
+    }
+    
+    // test around first line break 56, 57
+    
+    public void test56() throws Exception {
+        internalTest("size56", 56);
+    }
+    
+    public void test57() throws Exception {
+        internalTest("size57", 57);
+    }
+    
+    // test errors around 1023-1026
+    
+    public void test1023() throws Exception {
+        internalTest("size1023", 1023);
+    }
+    
+    public void test1024() throws Exception {
+        internalTest("size1024", 1024);
+    }
+    
+    public void test1025() throws Exception {
+        internalTest("size1025", 1025);
+    }
+    
+    public void test1026() throws Exception {
+        internalTest("size1026", 1026);
+    }
+    
+    // test 3069-3072
+    
+    public void test3069() throws Exception {
+        internalTest("size3069", 3069);
+    }
+    
+    public void test3070() throws Exception {
+        internalTest("size3070", 3070);
+    }
+    
+    public void test3071() throws Exception {
+        internalTest("size3071", 3071);
+    }
+    
+    public void test3072() throws Exception {
+        internalTest("size3072", 3072);
+    }
+}


### PR DESCRIPTION
Added a test unit using JDK DatatypeConverter to check (it exists in java 6, 7 and 8).